### PR TITLE
Feat: 도메인별 Entity 생성

### DIFF
--- a/src/main/java/com/KooKPaP/server/domain/member/entity/LoginType.java
+++ b/src/main/java/com/KooKPaP/server/domain/member/entity/LoginType.java
@@ -1,0 +1,5 @@
+package com.KooKPaP.server.domain.member.entity;
+
+public enum LoginType {
+    GENERAL, KAKAO
+}

--- a/src/main/java/com/KooKPaP/server/domain/member/entity/Member.java
+++ b/src/main/java/com/KooKPaP/server/domain/member/entity/Member.java
@@ -11,7 +11,7 @@ import javax.persistence.*;
 @Getter
 @Entity
 @Table(name = "Member")
-@SQLDelete(sql = "UPDATE member SET deleted_at = NOW() where member_id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
+@SQLDelete(sql = "UPDATE member SET deleted_at = NOW() where id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // 무분별한 생성자 사용을 막는 용도
 public class Member extends BaseTimeEntity {
 

--- a/src/main/java/com/KooKPaP/server/domain/member/entity/Member.java
+++ b/src/main/java/com/KooKPaP/server/domain/member/entity/Member.java
@@ -1,4 +1,39 @@
 package com.KooKPaP.server.domain.member.entity;
 
-public class Member {
+import com.KooKPaP.server.global.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Table(name = "Member")
+@SQLDelete(sql = "UPDATE member SET deleted_at = NOW() where member_id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 무분별한 생성자 사용을 막는 용도
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "password") // 카카오 로그인 시, 비밀번호 불필요하므로 nullable = true로 설정
+    private String password;
+
+    @Column(name = "type")
+    @Enumerated(EnumType.STRING) // ENUM Type을 DB에서는 String으로 관리하도록 설정
+    private LoginType type;
+
+    @Column(name = "role")
+    @Enumerated(EnumType.STRING)
+    private Role role;
 }

--- a/src/main/java/com/KooKPaP/server/domain/member/entity/Role.java
+++ b/src/main/java/com/KooKPaP/server/domain/member/entity/Role.java
@@ -1,0 +1,5 @@
+package com.KooKPaP.server.domain.member.entity;
+
+public enum Role {
+    CUSTOMER, MANAGER
+}

--- a/src/main/java/com/KooKPaP/server/domain/menu/entity/Menu.java
+++ b/src/main/java/com/KooKPaP/server/domain/menu/entity/Menu.java
@@ -1,0 +1,37 @@
+package com.KooKPaP.server.domain.menu.entity;
+
+import com.KooKPaP.server.domain.restaurant.entity.Restaurant;
+import com.KooKPaP.server.global.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Table(name = "Member")
+@SQLDelete(sql = "UPDATE menu SET deleted_at = NOW() where id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 무분별한 생성자 사용을 막는 용도
+public class Menu extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "price", nullable = false, columnDefinition = "int")
+    private Integer price;
+
+    @Column(name = "picture_url", columnDefinition = "text") // 이미지가 아닌, 이미지 주소를 저장하기에 네이밍 컨벤션 변경
+    private String pictureUrl;
+}

--- a/src/main/java/com/KooKPaP/server/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/KooKPaP/server/domain/restaurant/entity/Restaurant.java
@@ -1,0 +1,39 @@
+package com.KooKPaP.server.domain.restaurant.entity;
+
+import com.KooKPaP.server.domain.member.entity.Member;
+import com.KooKPaP.server.global.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Table(name = "Member")
+@SQLDelete(sql = "UPDATE restaurant SET deleted_at = NOW() where id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 무분별한 생성자 사용을 막는 용도
+public class Restaurant extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column(name = "location", nullable = false)
+    private String location;
+
+    @Column(name = "time", columnDefinition = "text")
+    private String time;
+
+    @Column(name = "call", nullable = false)
+    private String call;
+
+    @Column(name = "introduction", nullable = false, columnDefinition = "text")
+    private String introduction;
+}

--- a/src/main/java/com/KooKPaP/server/domain/review/entity/Review.java
+++ b/src/main/java/com/KooKPaP/server/domain/review/entity/Review.java
@@ -1,0 +1,41 @@
+package com.KooKPaP.server.domain.review.entity;
+
+import com.KooKPaP.server.domain.member.entity.Member;
+import com.KooKPaP.server.domain.restaurant.entity.Restaurant;
+import com.KooKPaP.server.global.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Table(name = "Member")
+@SQLDelete(sql = "UPDATE review SET deleted_at = NOW() where id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 무분별한 생성자 사용을 막는 용도
+public class Review extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+    @Column(name = "content", nullable = false, columnDefinition = "text")
+    private String content;
+
+    @Column(name = "rate", nullable = false, columnDefinition = "int")
+    private Integer rate;
+
+    @Column(name = "picture_url", columnDefinition = "text")
+    private String pictureUrl;
+}

--- a/src/main/java/com/KooKPaP/server/global/common/BaseTimeEntity.java
+++ b/src/main/java/com/KooKPaP/server/global/common/BaseTimeEntity.java
@@ -1,0 +1,28 @@
+package com.KooKPaP.server.global.common;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "createdAt", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modifiedAt", nullable = false)
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "deletedAt")
+    private LocalDateTime deletedAt;
+}


### PR DESCRIPTION
# PR Summary
- close #2 

## PR Detail Description
주요 작업
- BaseTimeEntity 생성
- Member Entity 생성
- Restaurant Entity 생성
- Menu Entity 생성
- Review Entity 생성

주요 사항
- FetchType.Lazy 사용: 지연 로딩이 N + 1 문제를 방지할 수 있기 때문에 ([관련 내용](https://ict-nroo.tistory.com/132))
- 논리적 삭제를 위한 SQLDelete 사용 ([관련 링크](https://velog.io/@max9106/JPA-soft-delete))

## Screenshots (Optional)
<img width="416" alt="image" src="https://github.com/KooK-PaP/kook-Pap-Server/assets/76556999/38cc7f7f-d39a-4b5b-b6e6-69794c76bfc0">

<img width="297" alt="image" src="https://github.com/KooK-PaP/kook-Pap-Server/assets/76556999/d9a725f0-b8e5-4753-9312-e2f1d46582fb">  

좌측의 기존 ERD 설계상 네이밍 컨벤션은 올바르지 않다고 생각되어서 우측과 같이 적용했습니다. 

