### PR TITLE
feat: entity 재설정 #12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+name: kookpap
+services:
+  redis:
+    container_name: kookpap-redis
+    image: redis:7.0.11
+    ports:
+      - "6379:6379"
+
+  mysql:
+    container_name: kookpap-db
+    image: mysql:8.0.33
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: kookpapdb
+      TZ: Asia/Seoul
+    ports:
+      - "3306:3306"
+    depends_on:
+      - redis

--- a/src/main/java/com/KooKPaP/server/domain/member/entity/Member.java
+++ b/src/main/java/com/KooKPaP/server/domain/member/entity/Member.java
@@ -36,4 +36,7 @@ public class Member extends BaseTimeEntity {
     @Column(name = "role")
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    @Column(name = "address", columnDefinition = "text") // MANAGER 에게는 딱히 필요 없을것 같아서 nullable = true로 설정
+    private String address;
 }

--- a/src/main/java/com/KooKPaP/server/domain/order/entity/Bucket.java
+++ b/src/main/java/com/KooKPaP/server/domain/order/entity/Bucket.java
@@ -24,25 +24,25 @@ public class Bucket extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
-    private Member member;
+    private Member member;          // 누가 주문했는지
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "restaurant_id")
-    private Restaurant restaurant;
+    private Restaurant restaurant;      // 어떤 가게에 주문을 했는지
 
     @Column(name = "state", nullable = false)
     @Enumerated(EnumType.STRING)
-    private OrderState state;
+    private BucketState state;          // 주문 상태 (처리 됐는지 안됐는지.. 등등)
 
     @Column(name = "total_price", nullable = false)
-    private Integer price;
+    private Integer totalPrice;         // 주문 총 금액
 
     @Builder
-    public Bucket(Long id, Member member, Restaurant restaurant, OrderState state, Integer price) {
+    public Bucket(Long id, Member member, Restaurant restaurant, BucketState state, Integer totalPrice) {
         this.id = id;
         this.member = member;
         this.restaurant = restaurant;
         this.state = state;
-        this.price = price;
+        this.totalPrice = totalPrice;
     }
 }

--- a/src/main/java/com/KooKPaP/server/domain/order/entity/Bucket.java
+++ b/src/main/java/com/KooKPaP/server/domain/order/entity/Bucket.java
@@ -1,4 +1,4 @@
-package com.KooKPaP.server.domain.review.entity;
+package com.KooKPaP.server.domain.order.entity;
 
 import com.KooKPaP.server.domain.member.entity.Member;
 import com.KooKPaP.server.domain.restaurant.entity.Restaurant;
@@ -13,11 +13,10 @@ import javax.persistence.*;
 
 @Getter
 @Entity
-@Table(name = "Review")
-@SQLDelete(sql = "UPDATE review SET deleted_at = NOW() where id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
+@Table(name = "Bucket")
+@SQLDelete(sql = "UPDATE menu SET deleted_at = NOW() where id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // 무분별한 생성자 사용을 막는 용도
-public class Review extends BaseTimeEntity {
-
+public class Bucket extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, columnDefinition = "bigint")
@@ -31,22 +30,19 @@ public class Review extends BaseTimeEntity {
     @JoinColumn(name = "restaurant_id")
     private Restaurant restaurant;
 
-    @Column(name = "content", nullable = false, columnDefinition = "text")
-    private String content;
+    @Column(name = "state", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private OrderState state;
 
-    @Column(name = "rate", nullable = false, columnDefinition = "int")
-    private Integer rate;
-
-    @Column(name = "picture_url", columnDefinition = "text")
-    private String pictureUrl;
+    @Column(name = "total_price", nullable = false)
+    private Integer price;
 
     @Builder
-    public Review(Long id, Member member, Restaurant restaurant, String content, Integer rate, String pictureUrl) {
+    public Bucket(Long id, Member member, Restaurant restaurant, OrderState state, Integer price) {
         this.id = id;
         this.member = member;
         this.restaurant = restaurant;
-        this.content = content;
-        this.rate = rate;
-        this.pictureUrl = pictureUrl;
+        this.state = state;
+        this.price = price;
     }
 }

--- a/src/main/java/com/KooKPaP/server/domain/order/entity/BucketState.java
+++ b/src/main/java/com/KooKPaP/server/domain/order/entity/BucketState.java
@@ -1,0 +1,7 @@
+package com.KooKPaP.server.domain.order.entity;
+
+public enum BucketState {
+    AWAITING_ACCEPT, // 접수 대기
+    ACCEPTED,       // 접수 완료
+    REFUSED,        // 접수 거절
+}

--- a/src/main/java/com/KooKPaP/server/domain/order/entity/Order.java
+++ b/src/main/java/com/KooKPaP/server/domain/order/entity/Order.java
@@ -1,47 +1,43 @@
-package com.KooKPaP.server.domain.menu.entity;
+package com.KooKPaP.server.domain.order.entity;
 
-import com.KooKPaP.server.domain.restaurant.entity.Restaurant;
-import com.KooKPaP.server.global.common.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.SQLDelete;
 
 import javax.persistence.*;
 
 @Getter
 @Entity
-@Table(name = "Menu")
+@Table(name = "Order")
 @SQLDelete(sql = "UPDATE menu SET deleted_at = NOW() where id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // 무분별한 생성자 사용을 막는 용도
-public class Menu extends BaseTimeEntity {
-
+public class Order {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, columnDefinition = "bigint")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "restaurant_id")
-    private Restaurant restaurant;
+    @JoinColumn(name = "bucket_id")
+    private Bucket bucket;
 
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "price", nullable = false, columnDefinition = "int")
+    @Column(name = "price", nullable = false)
     private Integer price;
 
-    @Column(name = "picture_url", columnDefinition = "text") // 이미지가 아닌, 이미지 주소를 저장하기에 네이밍 컨벤션 변경
-    private String pictureUrl;
+    @Column(name = "count", nullable = false)
+    private Integer count;
 
     @Builder
-    public Menu(Long id, Restaurant restaurant, String name, Integer price, String pictureUrl) {
+    public Order(Long id, Bucket bucket, String name, Integer price, Integer count) {
         this.id = id;
-        this.restaurant = restaurant;
+        this.bucket = bucket;
         this.name = name;
         this.price = price;
-        this.pictureUrl = pictureUrl;
+        this.count = count;
     }
 }

--- a/src/main/java/com/KooKPaP/server/domain/order/entity/OrderState.java
+++ b/src/main/java/com/KooKPaP/server/domain/order/entity/OrderState.java
@@ -1,0 +1,5 @@
+package com.KooKPaP.server.domain.order.entity;
+
+public enum OrderState {
+    AWAITING_ACCEPT, ACCEPTED, REFUSED,
+}

--- a/src/main/java/com/KooKPaP/server/domain/order/entity/OrderState.java
+++ b/src/main/java/com/KooKPaP/server/domain/order/entity/OrderState.java
@@ -1,5 +1,0 @@
-package com.KooKPaP.server.domain.order.entity;
-
-public enum OrderState {
-    AWAITING_ACCEPT, ACCEPTED, REFUSED,
-}

--- a/src/main/java/com/KooKPaP/server/domain/order/entity/Purchase.java
+++ b/src/main/java/com/KooKPaP/server/domain/order/entity/Purchase.java
@@ -10,10 +10,11 @@ import javax.persistence.*;
 
 @Getter
 @Entity
-@Table(name = "Order")
+@Table(name = "purchase")
 @SQLDelete(sql = "UPDATE menu SET deleted_at = NOW() where id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // 무분별한 생성자 사용을 막는 용도
-public class Order {
+public class Purchase {
+    // 음식 주문 내용에 해당하는 엔티티
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, columnDefinition = "bigint")
@@ -21,19 +22,19 @@ public class Order {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bucket_id")
-    private Bucket bucket;
+    private Bucket bucket;      // bucket은 장바구니의 역할을 수행
 
     @Column(name = "name", nullable = false)
-    private String name;
+    private String name;        // 주문 음식 이름
 
     @Column(name = "price", nullable = false)
-    private Integer price;
+    private Integer price;      // 주문 음식 가격
 
     @Column(name = "count", nullable = false)
-    private Integer count;
+    private Integer count;      // 주문 음식 수량
 
     @Builder
-    public Order(Long id, Bucket bucket, String name, Integer price, Integer count) {
+    public Purchase(Long id, Bucket bucket, String name, Integer price, Integer count) {
         this.id = id;
         this.bucket = bucket;
         this.name = name;

--- a/src/main/java/com/KooKPaP/server/domain/restaurant/entity/Operation.java
+++ b/src/main/java/com/KooKPaP/server/domain/restaurant/entity/Operation.java
@@ -15,6 +15,7 @@ import javax.persistence.*;
 @SQLDelete(sql = "UPDATE restaurant SET deleted_at = NOW() where id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // 무분별한 생성자 사용을 막는 용도
 public class Operation extends BaseTimeEntity {
+    // 가게가 영업을 시작하는 시간과 영업 종료하는 시간.
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false, columnDefinition = "bigint")

--- a/src/main/java/com/KooKPaP/server/domain/restaurant/entity/Operation.java
+++ b/src/main/java/com/KooKPaP/server/domain/restaurant/entity/Operation.java
@@ -1,0 +1,90 @@
+package com.KooKPaP.server.domain.restaurant.entity;
+
+import com.KooKPaP.server.global.common.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Table(name = "Operation")
+@SQLDelete(sql = "UPDATE restaurant SET deleted_at = NOW() where id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 무분별한 생성자 사용을 막는 용도
+public class Operation extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+    @Column(name = "mon_open")
+    private String monOpen;
+
+    @Column(name = "mon_close")
+    private String monClose;
+
+    @Column(name = "tue_open")
+    private String tueOpen;
+
+    @Column(name = "tue_close")
+    private String tueClose;
+
+    @Column(name = "wed_open")
+    private String wedOpen;
+
+    @Column(name = "wed_close")
+    private String wedClose;
+
+    @Column(name = "thu_open")
+    private String thuOpen;
+
+    @Column(name = "thu_close")
+    private String thuClose;
+
+    @Column(name = "fri_open")
+    private String friOpen;
+
+    @Column(name = "fri_close")
+    private String friClose;
+
+    @Column(name = "sat_open")
+    private String satOpen;
+
+    @Column(name = "sat_close")
+    private String satClose;
+
+    @Column(name = "sun_open")
+    private String sunOpen;
+
+    @Column(name = "sun_close")
+    private String sunClose;
+
+    @Builder
+    public Operation(Long id, Restaurant restaurant, String monOpen, String monClose, String tueOpen,
+                     String tueClose, String wedOpen, String wedClose, String thuOpen, String thuClose,
+                     String friOpen, String friClose, String satOpen, String satClose, String sunOpen, String sunClose) {
+        this.id = id;
+        this.restaurant = restaurant;
+        this.monOpen = monOpen;
+        this.monClose = monClose;
+        this.tueOpen = tueOpen;
+        this.tueClose = tueClose;
+        this.wedOpen = wedOpen;
+        this.wedClose = wedClose;
+        this.thuOpen = thuOpen;
+        this.thuClose = thuClose;
+        this.friOpen = friOpen;
+        this.friClose = friClose;
+        this.satOpen = satOpen;
+        this.satClose = satClose;
+        this.sunOpen = sunOpen;
+        this.sunClose = sunClose;
+    }
+}

--- a/src/main/java/com/KooKPaP/server/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/KooKPaP/server/domain/restaurant/entity/Restaurant.java
@@ -3,6 +3,7 @@ package com.KooKPaP.server.domain.restaurant.entity;
 import com.KooKPaP.server.domain.member.entity.Member;
 import com.KooKPaP.server.global.common.BaseTimeEntity;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -11,7 +12,7 @@ import javax.persistence.*;
 
 @Getter
 @Entity
-@Table(name = "Member")
+@Table(name = "Restaurant")
 @SQLDelete(sql = "UPDATE restaurant SET deleted_at = NOW() where id = ?") // SQL Delete 쿼리 시, 논리적 삭제로 바인딩되도록 하기 위한 용도
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // 무분별한 생성자 사용을 막는 용도
 public class Restaurant extends BaseTimeEntity {
@@ -28,12 +29,18 @@ public class Restaurant extends BaseTimeEntity {
     @Column(name = "location", nullable = false)
     private String location;
 
-    @Column(name = "time", columnDefinition = "text")
-    private String time;
-
     @Column(name = "call_number", nullable = false)
     private String callNumber;
 
     @Column(name = "introduction", nullable = false, columnDefinition = "text")
     private String introduction;
+
+    @Builder
+    public Restaurant(Long id, Member member, String location, String callNumber, String introduction) {
+        this.id = id;
+        this.member = member;
+        this.location = location;
+        this.callNumber = callNumber;
+        this.introduction = introduction;
+    }
 }

--- a/src/main/java/com/KooKPaP/server/domain/restaurant/entity/Restaurant.java
+++ b/src/main/java/com/KooKPaP/server/domain/restaurant/entity/Restaurant.java
@@ -26,20 +26,20 @@ public class Restaurant extends BaseTimeEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @Column(name = "location", nullable = false)
-    private String location;
+    @Column(name = "address", nullable = false)
+    private String address;     // 가게 주소
 
     @Column(name = "call_number", nullable = false)
-    private String callNumber;
+    private String callNumber;      // 가게 전화번호
 
     @Column(name = "introduction", nullable = false, columnDefinition = "text")
-    private String introduction;
+    private String introduction;        // 가게 설명
 
     @Builder
-    public Restaurant(Long id, Member member, String location, String callNumber, String introduction) {
+    public Restaurant(Long id, Member member, String address, String callNumber, String introduction) {
         this.id = id;
         this.member = member;
-        this.location = location;
+        this.address = address;
         this.callNumber = callNumber;
         this.introduction = introduction;
     }

--- a/src/main/java/com/KooKPaP/server/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/KooKPaP/server/global/common/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     JWT_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 JWT 토큰입니다.", 2002),
     JWT_UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원하지 않는 JWT 토큰입니다.", 2003),
     JWT_WRONG_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 JWT 토큰 입니다.", 2004),
+    JWT_ABSENCE_TOKEN(HttpStatus.UNAUTHORIZED, "JWT 토큰이 존재하지 않습니다.", 2005),
 
     // Member 관련
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.", 3001),

--- a/src/main/java/com/KooKPaP/server/global/jwt/JwtFilter.java
+++ b/src/main/java/com/KooKPaP/server/global/jwt/JwtFilter.java
@@ -1,6 +1,7 @@
 package com.KooKPaP.server.global.jwt;
 
 import com.KooKPaP.server.global.common.exception.CustomException;
+import com.KooKPaP.server.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -32,7 +33,7 @@ public class JwtFilter extends OncePerRequestFilter {
             if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
                 Authentication authentication = tokenProvider.getAuthentication(jwt);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
+            }else request.setAttribute("exception", ErrorCode.JWT_ABSENCE_TOKEN);
         } catch (CustomException e) {
             request.setAttribute("exception", e.getErrorCode());
         }


### PR DESCRIPTION
# PR Summary
- close #12 

## PR Detail Description
주요 작업:
- Bucket enity 작성
- Order entity 작성
- Restaurant의 time 칼럼을 Operation Column으로 따로 작성
- Member entity에 address 칼럼 추가

**Order는 Mysql 예약어이기 때문에 Purchase라는 이름으로 바꾸었습니다**
## Screenshots (Optional)
기존의 ERD:
https://user-images.githubusercontent.com/138233569/259628045-b802268a-4d6d-43ee-b65b-32ffc1914a76.png
위 ERD에서 비지니스 로직에 음식을 주문 로직을 추가하기 위하여 아래와 같이 변경되었습니다.

https://user-images.githubusercontent.com/138233569/267866020-60061ee1-16c4-49ec-8155-a000af68d970.png
- Order: 주문한 음식을 표현하는 엔티티
- Bucket: 주문에 대한 명세표를 표현하는 엔티티
- Operation: 현재 영업중인 가게를 조회하는데 수월하도록, 기존의 time column을 대체하는 엔티티를 새로 작성
- 비지니스 로직에, 음식 주문 로직이 추가되었기 때문에 member 테이블에 address Column이 추가되었습니다.