### PR TITLE
refactor: 스프링 시큐리티 미흡한 부분 보완

### DIFF
--- a/src/main/java/com/KooKPaP/server/ServerApplication.java
+++ b/src/main/java/com/KooKPaP/server/ServerApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableAsync
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class ServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/KooKPaP/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/KooKPaP/server/domain/member/controller/MemberController.java
@@ -13,6 +13,7 @@ import com.KooKPaP.server.global.common.exception.CustomException;
 import com.KooKPaP.server.global.common.exception.ErrorCode;
 import com.KooKPaP.server.global.jwt.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,7 +28,7 @@ public class MemberController {
 
     @GetMapping("/me")
     public ApplicationResponse<MemberInfoRes> getMyInfo(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-        Long id = principalDetails.getMember().getId();
+        Long id = principalDetails.getId();
         MemberInfoRes memberInfoRes = commonAuthService.getMemberInfo(id);
 
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, memberInfoRes);
@@ -36,7 +37,7 @@ public class MemberController {
     @PutMapping("/update")
     public ApplicationResponse<MemberInfoRes> memberUpdate(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                            @RequestBody MemberUpdateReq memberUpdateReq) {
-        Long id = principalDetails.getMember().getId();
+        Long id = principalDetails.getId();
         commonAuthService.updateMember(id, memberUpdateReq);
 
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, commonAuthService.getMemberInfo(id));
@@ -45,7 +46,7 @@ public class MemberController {
     @PatchMapping("/update/email")
     public ApplicationResponse<MemberInfoRes> memberEmailUpdate(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                 @RequestBody EmailReq emailReq) {
-        Long id = principalDetails.getMember().getId();
+        Long id = principalDetails.getId();
         String newEmail = emailReq.getEmail();
 
         if(!generalAuthService.isDuplicatedEmail(emailReq.getEmail()))
@@ -57,10 +58,10 @@ public class MemberController {
     @PostMapping("/password")
     public ApplicationResponse<?> verifyPassword(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                  @RequestBody PasswordReq passwordReq) {
-        if (principalDetails.getMember().getType()!= LoginType.GENERAL)
+        if (principalDetails.getType()!= LoginType.GENERAL)
             throw new CustomException(ErrorCode.AUTH_NOT_ALLOW_FOR_KAKAO_MEMBER);
 
-        Long id = principalDetails.getMember().getId();
+        Long id = principalDetails.getId();
         commonAuthService.verifyPassword(id, passwordReq.getPassword());
 
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, null);
@@ -69,10 +70,10 @@ public class MemberController {
     @PatchMapping("/password")
     public ApplicationResponse<?> updatePassword(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                  @RequestBody PasswordReq passwordReq) {
-        if (principalDetails.getMember().getType()!= LoginType.GENERAL)
+        if (principalDetails.getType()!= LoginType.GENERAL)
             throw new CustomException(ErrorCode.AUTH_NOT_ALLOW_FOR_KAKAO_MEMBER);
 
-        Long id = principalDetails.getMember().getId();
+        Long id = principalDetails.getId();
         commonAuthService.updatePassword(id, passwordReq.getPassword());
 
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, null);

--- a/src/main/java/com/KooKPaP/server/domain/member/service/CommonAuthService.java
+++ b/src/main/java/com/KooKPaP/server/domain/member/service/CommonAuthService.java
@@ -30,8 +30,8 @@ public class CommonAuthService {
 
     public JwtTokenDto reissue(String oldRefreshToken) {
         String value = (String) redisService.getValue(oldRefreshToken);
-        System.out.println(oldRefreshToken);
-        System.out.println(value);
+        if(value == null) throw (new CustomException(ErrorCode.JWT_INVALID_REFRESHTOKEN));
+
         if ("Deprecated".equals(value) || !jwtTokenProvider.validateToken(oldRefreshToken)) {
             // refresh 토큰이 블랙리스트에 존재하는지 검사 & 유효성 검사
             throw new CustomException(ErrorCode.AUTH_DEPRECATED_REFRESH_TOKEN);
@@ -55,7 +55,10 @@ public class CommonAuthService {
     }
 
     public void deleteMember(PrincipalDetails principalDetails) {
-        Member member = principalDetails.getMember();
+        Member member = memberRepository.findById(principalDetails.getId()).
+                orElseThrow(
+                        () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND)
+                );
         memberRepository.delete(member);
     }
 

--- a/src/main/java/com/KooKPaP/server/domain/member/service/KakaoAuthService.java
+++ b/src/main/java/com/KooKPaP/server/domain/member/service/KakaoAuthService.java
@@ -149,11 +149,10 @@ public class KakaoAuthService {
     public void serviceLogout(PrincipalDetails principalDetails){
         // 서비스 로그아웃(카카오)
         // 카카오 accessToken 만료
-        Member member = principalDetails.getMember();
+        if(principalDetails.getType() != LoginType.KAKAO) return;
 
-        if(member.getType() != LoginType.KAKAO) return;
-
-        OauthToken oauthToken = getOauthToken(member.getId());
+        Long id = principalDetails.getId();
+        OauthToken oauthToken = getOauthToken(id);
         if(oauthToken == null) return;
 
         System.out.println(oauthToken);
@@ -173,7 +172,7 @@ public class KakaoAuthService {
             );
 
             System.out.println("회원번호 " + response.getBody() + " 로그아웃");
-            redisService.deleteValue(member.getId().toString());
+            redisService.deleteValue(id.toString());
 
         } catch (Exception e) {
             return;

--- a/src/main/java/com/KooKPaP/server/domain/restaurant/controller/RestaurantController.java
+++ b/src/main/java/com/KooKPaP/server/domain/restaurant/controller/RestaurantController.java
@@ -27,19 +27,19 @@ public class RestaurantController {
     @Secured("ROLE_ADMIN")
     @PostMapping("/v{version}/restaurant/register")
     public ApplicationResponse<RestaurantRes> register(@PathVariable("version") Long version, @AuthenticationPrincipal PrincipalDetails principalDetails, @Valid @RequestBody RestaurantReq restaurantReq) {
-        Long memberId = principalDetails.getMember().getId();
+        Long memberId = principalDetails.getId();
         return ApplicationResponse.ok(ErrorCode.SUCCESS_CREATED, restaurantService.register(version, memberId, restaurantReq));
     }
 
     @PutMapping("/v{version}/restaurant/update/{restaurant_id}")
     public ApplicationResponse<RestaurantRes> update(@PathVariable("version") Long version, @AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("restaurant_id") Long restaurantId, @Valid @RequestBody RestaurantReq restaurantReq) {
-        Long memberId = principalDetails.getMember().getId();
+        Long memberId = principalDetails.getId();
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, restaurantService.update(version, memberId, restaurantId, restaurantReq));
     }
 
     @DeleteMapping("/v{version}/restaurant/delete/{restaurant_id}")
     public ApplicationResponse<Void> delete(@PathVariable("version") Long version, @AuthenticationPrincipal PrincipalDetails principalDetails, @PathVariable("restaurant_id") Long restaurantId) {
-        Long memberId = principalDetails.getMember().getId();
+        Long memberId = principalDetails.getId();
         restaurantService.delete(memberId, restaurantId);
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK);
     }
@@ -51,7 +51,7 @@ public class RestaurantController {
 
     @GetMapping("/v{version}/restaurant/my")
     public ApplicationResponse<List<RestaurantRes>> getMy(@PathVariable("version") Long version, @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        Long memberId = principalDetails.getMember().getId();
+        Long memberId = principalDetails.getId();
         return ApplicationResponse.ok(ErrorCode.SUCCESS_OK, restaurantService.getMy(memberId));
     }
 

--- a/src/main/java/com/KooKPaP/server/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/KooKPaP/server/global/common/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     AUTH_NOT_ALLOW_FOR_KAKAO_MEMBER(HttpStatus.BAD_REQUEST, "카카오로 회원가입하신 사용자는 사용할 수 없는 기능입니다.", 2018),
     AUTH_WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.", 2019),
     AUTH_NOT_ALLOWED_ACCESS(HttpStatus.BAD_REQUEST, "잘못된 접근입니다.", 2020),
+    JWT_INVALID_REFRESHTOKEN(HttpStatus.BAD_REQUEST,"잘못된 RTK입니다.",2021),
 
 
     // Member 관련 (3000번대)

--- a/src/main/java/com/KooKPaP/server/global/config/JwtSecurityConfig.java
+++ b/src/main/java/com/KooKPaP/server/global/config/JwtSecurityConfig.java
@@ -1,7 +1,7 @@
 package com.KooKPaP.server.global.config;
 
 import com.KooKPaP.server.global.common.service.RedisService;
-import com.KooKPaP.server.global.jwt.JwtFilter;
+import com.KooKPaP.server.global.filter.JwtFilter;
 import com.KooKPaP.server.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/KooKPaP/server/global/filter/JwtFilter.java
+++ b/src/main/java/com/KooKPaP/server/global/filter/JwtFilter.java
@@ -1,8 +1,10 @@
-package com.KooKPaP.server.global.jwt;
+package com.KooKPaP.server.global.filter;
 
 import com.KooKPaP.server.global.common.exception.CustomException;
 import com.KooKPaP.server.global.common.exception.ErrorCode;
 import com.KooKPaP.server.global.common.service.RedisService;
+import com.KooKPaP.server.global.jwt.JwtAttribute;
+import com.KooKPaP.server.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/src/main/java/com/KooKPaP/server/global/jwt/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/KooKPaP/server/global/jwt/CustomAccessDeniedHandler.java
@@ -12,13 +12,9 @@ import java.io.IOException;
 @Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     // 인가 관련 에러 처리, 403
-    // 나중에 API 설계 완료되면 해당 클래스 커스텀할 예정
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        accessDeniedException.getCause().printStackTrace();
 
-        response.setContentType("application/json;charset=UTF-8");
-        response.getWriter().write(accessDeniedException.getMessage());
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
     }
 }

--- a/src/main/java/com/KooKPaP/server/global/jwt/PrincipalDetails.java
+++ b/src/main/java/com/KooKPaP/server/global/jwt/PrincipalDetails.java
@@ -1,6 +1,10 @@
 package com.KooKPaP.server.global.jwt;
 
+import com.KooKPaP.server.domain.member.entity.LoginType;
 import com.KooKPaP.server.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -8,34 +12,42 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.ArrayList;
 import java.util.Collection;
 
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class PrincipalDetails implements UserDetails {
-    private Member member;
+    private Long id;
+    private SimpleGrantedAuthority authority;
+    private LoginType type;
 
-    public PrincipalDetails(Member member) {
-        this.member = member;
+
+    public Long getId(){
+        return id;
     }
 
-    public Member getMember(){
-        return member;
+    public LoginType getType(){
+        return type;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         // 권한 정보 반환
         Collection<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
-        authorities.add(new SimpleGrantedAuthority("ROLE_" + member.getRole().toString()));
+
+        // 각 멤버들은 하나의 권한만 갖도록 설계됨.
+        authorities.add(authority);
 
         return authorities;
     }
 
     @Override
     public String getPassword() {
-        return member.getPassword();
+        return null;
     }
 
     @Override
     public String getUsername() {
-        return member.getName();
+        return null;
     }
 
     @Override

--- a/src/main/java/com/KooKPaP/server/global/jwt/PrincipalDetails.java
+++ b/src/main/java/com/KooKPaP/server/global/jwt/PrincipalDetails.java
@@ -23,7 +23,7 @@ public class PrincipalDetails implements UserDetails {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         // 권한 정보 반환
         Collection<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
-        authorities.add(new SimpleGrantedAuthority(member.getRole().toString()));
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + member.getRole().toString()));
 
         return authorities;
     }

--- a/src/main/java/com/KooKPaP/server/global/jwt/tokenDto/JwtTokenDto.java
+++ b/src/main/java/com/KooKPaP/server/global/jwt/tokenDto/JwtTokenDto.java
@@ -10,7 +10,7 @@ public class JwtTokenDto {
     private String grantType;
     private String accessToken;
     private String refreshToken;
-    private long accessTokenExpiresIn;
+    private long accessTokenExpiresIn; // 밀리세컨드 단위
 
 
     @Builder


### PR DESCRIPTION
# PR Summary
- #25 
- authority를 어노테이션을 통해 제한 가능
- PrincipalDetails 구조 변경
- JwtTokenProvider의 JWT 토큰 구조 변경

## PR Detail Description
- 기존 코드 상의 authority는 미흡한 점이 많아, 제대로 동작하지 않았습니다. 이를 고쳐  @PreAuthorize와 같은 어노테이션을 활용한 접근 제한이 가능하도록 수정하였습니다.
- 기존 PrincipalDetails에는 Member 객체가 포함되어있어, Service 레이어에서 member.getId()를 통해 ID를 추출후, 다시 repository를 통해 Member를 검색해야되는 비효율성이 존재했습니다. 따라서 PrincipalDetails에는 Member의 Id, LoginType, Role이 포함되도록 수정되었습니다.
- 위 3가지 필드는 JWT 토큰의 Claim으로 저장되도록 JWT의 구조를 변경하였습니다.

 기존의 Member 조회 쿼리 발생은 다음과 같이 발생했습니다.
1. JwtTokenProvider에서 Member 조회 쿼리 수행 (JWT에 존재하는 Id로 Member 조회) 후 PrincipalDetails에 저장
2. 이후, Service 레이어에서 memberId로 (PrincipalDetails에 존재하는 Member의 Id) 다시 Member를 조회

PrincipalDetails에 Member가 아닌, memberId를 저장하여, 조회 쿼리를 1번만 발생하도록 줄였습니다.

Claim에 LoginType이 들어간 이유 :
- 로그아웃, 비밀번호 변경과 같이 LoginType에 따라 로직이 다르게 수행되야 하는 경우가 존재하여, PrincipalDetails에 포함시켰습니다.

Claim에 Role이 들어간 이유 :
- Controller 메서드가 실행되기 전, 해당 사용자의 권한을 알아야 하기 때문에 PrincipalDetails에 포함시켰습니다.

## Screenshots (Optional)

-
